### PR TITLE
Add Azure Devops native support to integrations list

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -5,6 +5,7 @@ The following is a list of different integrations and plugins where mermaid is b
 ## Productivity
 
 - [GitLab](https://docs.gitlab.com/ee/user/markdown.html#diagrams-and-flowcharts) (**Native support**)
+- [Azure Devops](https://docs.microsoft.com/en-us/azure/devops/project/wiki/wiki-markdown-guidance?view=azure-devops#add-mermaid-diagrams-to-a-wiki-page) (**Native support**)
 - [GitHub](https://github.com)
   - [Github action: Compile mermaid to image](https://github.com/neenjaw/compile-mermaid-markdown-action)
   - [svg-generator](https://github.com/SimonKenyonShepard/mermaidjs-github-svg-generator)


### PR DESCRIPTION
## :bookmark_tabs: Summary
Add Azure Devops native support to integrations list.

### :clipboard: Tasks
Make sure you
- [X] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [X] :computer: have added unit/e2e tests (if appropriate) 
- [X] :bookmark: targeted `develop` branch 
